### PR TITLE
Refactor notebook to use pure Python helpers

### DIFF
--- a/Culture_Explorer.ipynb
+++ b/Culture_Explorer.ipynb
@@ -7,17 +7,17 @@
    "source": [
     "# Culture Explorer: World & European Values Survey Toolkit\n",
     "\n",
-    "This notebook delivers an end-to-end cultural analytics workspace that can be executed in Google Colab. It combines an interactive Leaflet.js map (powered by **folium**), comparison dashboards, a FastAPI backend, and OpenAI-powered cultural insights to satisfy the requirements outlined in the project brief.\n",
+    "This notebook delivers an end-to-end cultural analytics workspace that can be executed in Google Colab. It combines an interactive Leaflet.js map (powered by **folium**), comparison dashboards, a pure Python helper layer, and OpenAI-powered cultural insights to satisfy the requirements outlined in the project brief.\n",
     "\n",
     "**What you can do here:**\n",
     "\n",
     "* Explore World Values Survey (WVS) and European Values Survey (EVS) indicators on a global map.\n",
     "* Build comparison matrices for arbitrary sets of countries, fine-tuning the weight of individual survey questions through interactive controls.\n",
-    "* Capture retrospective and future survey measurements directly inside the notebook or via the API.\n",
+    "* Capture retrospective and future survey measurements directly inside the notebook or via the helper service methods.\n",
     "* Create family or team groups, collect their survey responses, and match their profiles to the closest countries.\n",
     "* Plug in an OpenAI API key to obtain reusable cultural briefings, collaboration advice, and conflict mediation guidance from the survey scores.\n",
     "\n",
-    "> **Data**: A small representative CSV is bundled inside the repository for offline execution. In a Colab environment you can replace it with the official WVS/EVS extracts placed under the `data/` folder."
+    "> **Data**: A small representative CSV is bundled inside the repository for offline execution. In a Colab environment you can replace it with the official WVS/EVS extracts placed under the `data/` folder.\n"
    ]
   },
   {
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "7d85f9c8",
    "metadata": {
     "execution": {
@@ -42,18 +42,9 @@
      "shell.execute_reply": "2025-10-02T16:16:12.742017Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\r\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install -q fastapi uvicorn folium ipywidgets plotly openai nest_asyncio pandas numpy pdfplumber\n"
+    "!pip install -q folium ipywidgets plotly openai pandas numpy pdfplumber\n"
    ]
   },
   {
@@ -66,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "d9e0ce0d",
    "metadata": {
     "execution": {
@@ -76,137 +67,7 @@
      "shell.execute_reply": "2025-10-02T16:16:15.640361Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "Loaded **48** survey records spanning **4** countries."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Country</th>\n",
-       "      <th>ISO3</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Year</th>\n",
-       "      <th>Source</th>\n",
-       "      <th>QuestionGroup</th>\n",
-       "      <th>Question</th>\n",
-       "      <th>Score</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>United States</td>\n",
-       "      <td>USA</td>\n",
-       "      <td>38.9</td>\n",
-       "      <td>-77.04</td>\n",
-       "      <td>2020</td>\n",
-       "      <td>WVS</td>\n",
-       "      <td>Trust &amp; Civic Engagement</td>\n",
-       "      <td>Generalized Trust</td>\n",
-       "      <td>0.62</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>United States</td>\n",
-       "      <td>USA</td>\n",
-       "      <td>38.9</td>\n",
-       "      <td>-77.04</td>\n",
-       "      <td>2020</td>\n",
-       "      <td>WVS</td>\n",
-       "      <td>Trust &amp; Civic Engagement</td>\n",
-       "      <td>Volunteering Rate</td>\n",
-       "      <td>0.55</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>United States</td>\n",
-       "      <td>USA</td>\n",
-       "      <td>38.9</td>\n",
-       "      <td>-77.04</td>\n",
-       "      <td>2020</td>\n",
-       "      <td>WVS</td>\n",
-       "      <td>Traditional vs Secular Values</td>\n",
-       "      <td>Religious Importance</td>\n",
-       "      <td>0.45</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>United States</td>\n",
-       "      <td>USA</td>\n",
-       "      <td>38.9</td>\n",
-       "      <td>-77.04</td>\n",
-       "      <td>2020</td>\n",
-       "      <td>WVS</td>\n",
-       "      <td>Traditional vs Secular Values</td>\n",
-       "      <td>Respect for Authority</td>\n",
-       "      <td>0.52</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>United States</td>\n",
-       "      <td>USA</td>\n",
-       "      <td>38.9</td>\n",
-       "      <td>-77.04</td>\n",
-       "      <td>2020</td>\n",
-       "      <td>WVS</td>\n",
-       "      <td>Survival vs Self-Expression</td>\n",
-       "      <td>Life Satisfaction</td>\n",
-       "      <td>0.72</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "         Country ISO3  Latitude  Longitude  Year Source  \\\n",
-       "0  United States  USA      38.9     -77.04  2020    WVS   \n",
-       "1  United States  USA      38.9     -77.04  2020    WVS   \n",
-       "2  United States  USA      38.9     -77.04  2020    WVS   \n",
-       "3  United States  USA      38.9     -77.04  2020    WVS   \n",
-       "4  United States  USA      38.9     -77.04  2020    WVS   \n",
-       "\n",
-       "                   QuestionGroup               Question  Score  \n",
-       "0       Trust & Civic Engagement      Generalized Trust   0.62  \n",
-       "1       Trust & Civic Engagement      Volunteering Rate   0.55  \n",
-       "2  Traditional vs Secular Values   Religious Importance   0.45  \n",
-       "3  Traditional vs Secular Values  Respect for Authority   0.52  \n",
-       "4    Survival vs Self-Expression      Life Satisfaction   0.72  "
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import hashlib\n",
@@ -215,7 +76,6 @@
     "from typing import Dict, List, Optional, Tuple\n",
     "from itertools import groupby\n",
     "\n",
-    "import nest_asyncio\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
@@ -227,12 +87,6 @@
     "\n",
     "import plotly.graph_objects as go\n",
     "\n",
-    "from fastapi import FastAPI, HTTPException\n",
-    "from fastapi.middleware.cors import CORSMiddleware\n",
-    "from fastapi.responses import JSONResponse\n",
-    "from fastapi.testclient import TestClient\n",
-    "from pydantic import BaseModel\n",
-    "\n",
     "try:\n",
     "    from openai import OpenAI\n",
     "except ImportError:  # pragma: no cover - handled gracefully in environments without openai\n",
@@ -243,8 +97,6 @@
     "except ImportError:  # pragma: no cover - optional dependency for parsing PDF catalogues\n",
     "    pdfplumber = None\n",
     "\n",
-    "nest_asyncio.apply()\n",
-    "\n",
     "DATA_DIR = Path(\"data\")\n",
     "CACHE_PATH = DATA_DIR / \"openai_response_cache.json\"\n",
     "COUNTRY_PATH = DATA_DIR / \"country.csv\"\n",
@@ -254,10 +106,8 @@
     "\n",
     "QUESTION_CODE_PATTERN = re.compile(r'^([A-Za-z]+\\d+[A-Za-z0-9-]*)$')\n",
     "\n",
-    "\n",
     "def _sanitise_column_name(name: str) -> str:\n",
     "    return re.sub(r'[^a-z0-9]', '', str(name).lower())\n",
-    "\n",
     "\n",
     "def derive_standard_column_mapping(columns: List[str], entity_type: str) -> Dict[str, str]:\n",
     "    patterns = {\n",
@@ -294,17 +144,12 @@
     "            mapping[match] = target\n",
     "    return mapping\n",
     "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
     "def _looks_like_pdf(path: Path) -> bool:\n",
     "    try:\n",
     "        with path.open(\"rb\") as handle:\n",
     "            return handle.read(4) == b\"%PDF\"\n",
     "    except OSError:\n",
     "        return False\n",
-    "\n",
     "\n",
     "def find_question_catalogue(data_dir: Path) -> Optional[Path]:\n",
     "    search_roots = [\n",
@@ -334,7 +179,6 @@
     "            seen.add(candidate)\n",
     "    prioritised = [path for path in unique_candidates if \"question\" in path.name.lower()]\n",
     "    return prioritised[0] if prioritised else (unique_candidates[0] if unique_candidates else None)\n",
-    "\n",
     "\n",
     "def extract_official_question_titles(pdf_path: Path) -> Dict[str, str]:\n",
     "    if pdfplumber is None:\n",
@@ -372,17 +216,13 @@
     "                        else:\n",
     "                            idx += 1\n",
     "    except Exception as exc:  # pragma: no cover - parsing quality depends on PDF formatting\n",
-    "        display(Markdown(f'⚠️ **Warning:** Unable to parse `{pdf_path.name}` for question titles ({exc}).'))\n",
+    "        display(Markdown(f'\u26a0\ufe0f **Warning:** Unable to parse `{pdf_path.name}` for question titles ({exc}).'))\n",
     "    return question_titles\n",
-    "\n",
     "\n",
     "def normalise_headers(df: pd.DataFrame) -> pd.DataFrame:\n",
     "    df = df.copy()\n",
     "    df.columns = [str(col).strip() for col in df.columns]\n",
     "    return df\n",
-    "\n",
-    "\n",
-    "\n",
     "\n",
     "def ensure_required_columns(df: pd.DataFrame, entity_type: str) -> pd.DataFrame:\n",
     "    df = df.copy()\n",
@@ -406,9 +246,6 @@
     "                break\n",
     "        df['Area'] = df[fallback] if fallback else 'Unknown'\n",
     "    return df\n",
-    "\n",
-    "\n",
-    "\n",
     "\n",
     "def summarise_spreadsheet(path: Path, titles: Dict[str, str]) -> Dict[str, object]:\n",
     "    if not path.exists():\n",
@@ -450,7 +287,6 @@
     "        if QUESTION_CODE_PATTERN.match(str(col))\n",
     "    ]\n",
     "    return {\"columns\": columns, \"first_row\": first_row, \"question_index\": question_index}\n",
-    "\n",
     "\n",
     "def load_culture_frame(path: Path, entity_type: str, titles: Dict[str, str]) -> pd.DataFrame:\n",
     "    if not path.exists():\n",
@@ -504,7 +340,7 @@
     "            area_column = \"Area\"\n",
     "        melted[\"ParentCountry\"] = melted[\"Country\"].astype(str)\n",
     "        melted[\"DisplayName\"] = (\n",
-    "            melted[area_column].astype(str).str.strip() + \" — \" + melted[\"ParentCountry\"].astype(str).str.strip()\n",
+    "            melted[area_column].astype(str).str.strip() + \" \u2014 \" + melted[\"ParentCountry\"].astype(str).str.strip()\n",
     "        )\n",
     "        melted[\"Country\"] = melted[\"DisplayName\"]\n",
     "\n",
@@ -533,7 +369,6 @@
     "    melted[\"Country\"] = melted[\"Country\"].astype(str)\n",
     "    melted[\"ParentCountry\"] = melted[\"ParentCountry\"].astype(str)\n",
     "    return melted.reset_index(drop=True)\n",
-    "\n",
     "\n",
     "QUESTION_PDF = find_question_catalogue(DATA_DIR)\n",
     "OFFICIAL_TITLES = extract_official_question_titles(QUESTION_PDF) if QUESTION_PDF else {}\n",
@@ -579,7 +414,7 @@
     ")\n",
     "\n",
     "if country_summary[\"columns\"]:\n",
-    "    display(Markdown(\"**Country data — first row preview (first 10 columns):**\"))\n",
+    "    display(Markdown(\"**Country data \u2014 first row preview (first 10 columns):**\"))\n",
     "    preview_cols = country_summary[\"columns\"][:10]\n",
     "    display(pd.DataFrame([country_summary[\"first_row\"]])[preview_cols])\n",
     "\n",
@@ -1200,7 +1035,7 @@
     "    if df.empty:\n",
     "        return \"<p>No responses available for the selected year.</p>\"\n",
     "    pivot = df.pivot_table(index=\"QuestionGroup\", columns=\"Question\", values=\"Score\")\n",
-    "    pivot = pivot.sort_index().round(3).fillna(\"—\")\n",
+    "    pivot = pivot.sort_index().round(3).fillna(\"\u2014\")\n",
     "    return pivot.to_html(classes=\"culture-profile-table\", border=0)\n",
     "\n",
     "\n",
@@ -1324,7 +1159,7 @@
     "            const parentLine = item.entityType === 'location' ? `<p><strong>Parent country:</strong> ${item.parent}</p>` : '';\n",
     "            content.innerHTML = `<h4 style=\"margin:0 0 8px 0;\">${item.title}</h4>` +\n",
     "                `<p style=\\\"margin:0 0 8px 0;\\\"><strong>Question:</strong> ${item.question} (${item.questionGroup})</p>` +\n",
-    "                `<p style=\\\"margin:0 0 12px 0;\\\"><strong>Score:</strong> ${item.score} &nbsp;·&nbsp; ${item.source} (${item.year})</p>` +\n",
+    "                `<p style=\\\"margin:0 0 12px 0;\\\"><strong>Score:</strong> ${item.score} &nbsp;\u00b7&nbsp; ${item.source} (${item.year})</p>` +\n",
     "                parentLine +\n",
     "                item.profileHtml;\n",
     "            addBtn.disabled = false;\n",
@@ -1427,7 +1262,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(SelectMultiple(description='Countries', index=(0, 1, 2), layout=Layout(height='2…"
+       "VBox(children=(HBox(children=(SelectMultiple(description='Countries', index=(0, 1, 2), layout=Layout(height='2\u2026"
       ]
      },
      "metadata": {},
@@ -1470,7 +1305,7 @@
     "                    min=0.0,\n",
     "                    max=2.0,\n",
     "                    step=0.05,\n",
-    "                    description=question[:22] + ('…' if len(question) > 22 else ''),\n",
+    "                    description=question[:22] + ('\u2026' if len(question) > 22 else ''),\n",
     "                    readout=True,\n",
     "                    readout_format='.2f',\n",
     "                    style={'description_width': 'initial'},\n",
@@ -1591,7 +1426,7 @@
    "source": [
     "## 6. Family and team survey capture\n",
     "\n",
-    "Record member scores (normalised 0–1) for a family or team group below. After adding members you can finalise the profile to discover the nearest national culture using Euclidean similarity across the shared question space."
+    "Record member scores (normalised 0\u20131) for a family or team group below. After adding members you can finalise the profile to discover the nearest national culture using Euclidean similarity across the shared question space."
    ]
   },
   {
@@ -1615,7 +1450,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HBox(children=(ToggleButtons(description='Group type', options=(('Family', 'family'), ('Team', …"
+       "VBox(children=(HBox(children=(ToggleButtons(description='Group type', options=(('Family', 'family'), ('Team', \u2026"
       ]
      },
      "metadata": {},
@@ -1652,7 +1487,7 @@
     "                    min=0.0,\n",
     "                    max=1.0,\n",
     "                    step=0.01,\n",
-    "                    description=question[:28] + ('…' if len(question) > 28 else ''),\n",
+    "                    description=question[:28] + ('\u2026' if len(question) > 28 else ''),\n",
     "                    style={'description_width': 'initial'},\n",
     "                    readout=True,\n",
     "                    readout_format='.2f',\n",
@@ -1691,12 +1526,12 @@
     "            )\n",
     "            with self.output:\n",
     "                clear_output(wait=True)\n",
-    "                display(Markdown(f\"✅ Added survey for **{self.member_name.value}**.\"))\n",
+    "                display(Markdown(f\"\u2705 Added survey for **{self.member_name.value}**.\"))\n",
     "            self.member_name.value = ''\n",
     "        except Exception as exc:\n",
     "            with self.output:\n",
     "                clear_output(wait=True)\n",
-    "                display(Markdown(f\"⚠️ {exc}\"))\n",
+    "                display(Markdown(f\"\u26a0\ufe0f {exc}\"))\n",
     "\n",
     "    def _handle_finalise(self, _):\n",
     "        try:\n",
@@ -1712,7 +1547,7 @@
     "        except Exception as exc:\n",
     "            with self.output:\n",
     "                clear_output(wait=True)\n",
-    "                display(Markdown(f\"⚠️ {exc}\"))\n",
+    "                display(Markdown(f\"\u26a0\ufe0f {exc}\"))\n",
     "\n",
     "    def display(self):\n",
     "        display(self.form)\n",
@@ -1726,12 +1561,13 @@
    "id": "60c961b8",
    "metadata": {},
    "source": [
-    "## 7. FastAPI backend"
+    "## 7. Pure Python backend helpers\n",
+    "The previous FastAPI layer has been replaced with lightweight utility functions so that everything runs natively within this notebook.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "ea8bb839",
    "metadata": {
     "execution": {
@@ -1741,130 +1577,66 @@
      "shell.execute_reply": "2025-10-02T16:16:16.557244Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "To launch the API locally run:\n",
-       "```\n",
-       "import uvicorn\n",
-       "uvicorn.run(app, host='0.0.0.0', port=8000)\n",
-       "```"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "app = FastAPI(title=\"Culture Explorer API\", version=\"1.0\")\n",
-    "app.add_middleware(\n",
-    "    CORSMiddleware,\n",
-    "    allow_origins=[\"*\"],\n",
-    "    allow_credentials=True,\n",
-    "    allow_methods=[\"*\"],\n",
-    "    allow_headers=[\"*\"],\n",
-    ")\n",
+    "class CultureExplorerService:\n",
+    "    \"\"\"Convenience wrapper exposing culture analytics without requiring a web framework.\"\"\"\n",
     "\n",
-    "class ScoreRequest(BaseModel):\n",
-    "    countries: List[str]\n",
-    "    year: int\n",
+    "    def __init__(self, dataset: CulturalDataset, group_manager: GroupManager, insight_generator: OpenAIInsightGenerator):\n",
+    "        self.dataset = dataset\n",
+    "        self.group_manager = group_manager\n",
+    "        self.insight_generator = insight_generator\n",
     "\n",
-    "class NewRecord(BaseModel):\n",
-    "    Country: str\n",
-    "    ISO3: str\n",
-    "    Latitude: float\n",
-    "    Longitude: float\n",
-    "    Year: int\n",
-    "    Source: str\n",
-    "    QuestionGroup: str\n",
-    "    Question: str\n",
-    "    QuestionCode: Optional[str] = None\n",
-    "    Score: float\n",
-    "    EntityType: str = \"country\"\n",
-    "    ParentCountry: Optional[str] = None\n",
+    "    def get_countries(self) -> List[str]:\n",
+    "        return self.dataset.get_countries()\n",
     "\n",
-    "class GroupMemberPayload(BaseModel):\n",
-    "    group_name: str\n",
-    "    member_name: str\n",
-    "    group_type: str = \"team\"\n",
-    "    reference_year: Optional[int] = None\n",
-    "    responses: Dict[str, Dict[str, float]]\n",
+    "    def get_years(self) -> List[int]:\n",
+    "        return self.dataset.get_years()\n",
     "\n",
-    "class InsightRequest(BaseModel):\n",
-    "    template_key: str\n",
-    "    payload: Dict[str, object]\n",
+    "    def get_groups(self) -> Dict[str, List[str]]:\n",
+    "        return self.dataset.get_group_questions()\n",
     "\n",
-    "@app.get(\"/countries\")\n",
-    "def get_countries():\n",
-    "    return {\"countries\": dataset.get_countries()}\n",
+    "    def get_score_matrix(self, countries: List[str], year: int, group: Optional[str] = None) -> pd.DataFrame:\n",
+    "        return self.dataset.get_question_matrix(countries, year, group)\n",
     "\n",
-    "@app.get(\"/years\")\n",
-    "def get_years():\n",
-    "    return {\"years\": dataset.get_years()}\n",
+    "    def add_record(self, record: Dict[str, object]) -> Dict[str, object]:\n",
+    "        self.dataset.add_record(record)\n",
+    "        return {\"status\": \"ok\", \"records\": len(self.dataset.data), \"entities\": self.dataset.get_countries()}\n",
     "\n",
-    "@app.get(\"/groups\")\n",
-    "def get_groups():\n",
-    "    return {\"groups\": dataset.get_group_questions()}\n",
-    "\n",
-    "@app.post(\"/scores\")\n",
-    "def post_scores(request: ScoreRequest):\n",
-    "    try:\n",
-    "        matrix = dataset.get_question_matrix(request.countries, request.year)\n",
-    "    except ValueError as exc:\n",
-    "        raise HTTPException(status_code=404, detail=str(exc))\n",
-    "    return json.loads(matrix.round(4).to_json())\n",
-    "\n",
-    "@app.post(\"/data\")\n",
-    "def ingest_record(record: NewRecord):\n",
-    "    payload = record.dict(exclude_unset=True)\n",
-    "    dataset.add_record(payload)\n",
-    "    return {\n",
-    "        \"status\": \"ok\",\n",
-    "        \"records\": len(dataset.data),\n",
-    "        \"entities\": dataset.get_countries(),\n",
-    "    }\n",
-    "\n",
-    "@app.post(\"/groups/member\")\n",
-    "def add_group_member(payload: GroupMemberPayload):\n",
-    "    responses = {}\n",
-    "    for group, questions in payload.responses.items():\n",
-    "        for question, score in questions.items():\n",
-    "            responses[(group, question)] = score\n",
-    "    try:\n",
-    "        group_manager.add_member(\n",
-    "            group_name=payload.group_name,\n",
-    "            member_name=payload.member_name,\n",
-    "            responses=responses,\n",
-    "            group_type=payload.group_type,\n",
-    "            reference_year=payload.reference_year,\n",
+    "    def add_group_member(\n",
+    "        self,\n",
+    "        group_name: str,\n",
+    "        member_name: str,\n",
+    "        responses: Dict[str, Dict[str, float]],\n",
+    "        group_type: str = \"team\",\n",
+    "        reference_year: Optional[int] = None,\n",
+    "    ) -> Dict[str, object]:\n",
+    "        flattened = {\n",
+    "            (group, question): score\n",
+    "            for group, questions in responses.items()\n",
+    "            for question, score in questions.items()\n",
+    "        }\n",
+    "        self.group_manager.add_member(\n",
+    "            group_name=group_name,\n",
+    "            member_name=member_name,\n",
+    "            responses=flattened,\n",
+    "            group_type=group_type,\n",
+    "            reference_year=reference_year,\n",
     "        )\n",
-    "    except ValueError as exc:\n",
-    "        raise HTTPException(status_code=400, detail=str(exc))\n",
-    "    return {\"status\": \"ok\"}\n",
+    "        members = self.group_manager.get_group_members(group_name)\n",
+    "        return {\"status\": \"ok\", \"members\": sorted(members.keys())}\n",
     "\n",
-    "@app.get(\"/groups/{group_name}\")\n",
-    "def get_group_profile(group_name: str):\n",
-    "    try:\n",
-    "        profile = group_manager.compute_group_profile(group_name)\n",
-    "    except (KeyError, ValueError) as exc:\n",
-    "        raise HTTPException(status_code=404, detail=str(exc))\n",
-    "    return json.loads(profile.to_json())\n",
+    "    def get_group_profile(self, group_name: str) -> pd.Series:\n",
+    "        return self.group_manager.compute_group_profile(group_name)\n",
     "\n",
-    "@app.post(\"/insights\")\n",
-    "def generate_insight(request: InsightRequest):\n",
-    "    try:\n",
-    "        message = insight_generator.generate(request.template_key, **request.payload)\n",
-    "    except KeyError as exc:\n",
-    "        raise HTTPException(status_code=400, detail=str(exc))\n",
-    "    if message.startswith(\"OpenAI client not configured\"):\n",
-    "        return JSONResponse(status_code=503, content={\"detail\": message})\n",
-    "    return {\"message\": message}\n",
+    "    def match_group_to_countries(self, group_name: str, year: Optional[int] = None) -> pd.DataFrame:\n",
+    "        return self.group_manager.match_closest_country(group_name, year)\n",
     "\n",
-    "display(Markdown(\"To launch the API locally run:\\n```\\nimport uvicorn\\nuvicorn.run(app, host='0.0.0.0', port=8000)\\n```\"))"
+    "    def generate_insight(self, template_key: str, **payload: object) -> str:\n",
+    "        return self.insight_generator.generate(template_key, **payload)\n",
+    "\n",
+    "service = CultureExplorerService(dataset, group_manager, insight_generator)\n",
+    "display(Markdown(\"Pure Python helper `service` initialised. Use its methods to explore and manipulate the dataset without running a web server.\"))\n"
    ]
   },
   {
@@ -1872,12 +1644,13 @@
    "id": "3af10943",
    "metadata": {},
    "source": [
-    "## 8. Automated API smoke tests"
+    "## 8. Backend helper verification\n",
+    "Quick smoke-tests ensure the lightweight service behaves as expected when called directly from Python.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "ad4e9a7d",
    "metadata": {
     "execution": {
@@ -1887,52 +1660,45 @@
      "shell.execute_reply": "2025-10-02T16:16:16.660123Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_9852/3753350942.py:58: PydanticDeprecatedSince20:\n",
-      "\n",
-      "The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "✅ FastAPI endpoints responded successfully."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "client = TestClient(app)\n",
-    "assert client.get('/countries').status_code == 200\n",
-    "assert client.get('/years').status_code == 200\n",
-    "assert client.get('/groups').status_code == 200\n",
-    "response = client.post('/scores', json={'countries': dataset.get_countries()[:2], 'year': max(dataset.get_years())})\n",
-    "assert response.status_code == 200\n",
+    "latest_year = max(service.get_years())\n",
+    "sample_countries = service.get_countries()[:2]\n",
+    "matrix = service.get_score_matrix(sample_countries, latest_year)\n",
+    "\n",
+    "display(Markdown(\n",
+    "    f\"Validated helper service with {len(service.get_countries())} countries and {len(service.get_years())} years of data.\"\n",
+    "))\n",
+    "display(matrix.head())\n",
+    "\n",
     "sample_record = {\n",
     "    'Country': 'Testland',\n",
     "    'ISO3': 'TST',\n",
     "    'Latitude': 10.0,\n",
     "    'Longitude': 20.0,\n",
-    "    'Year': 2030,\n",
+    "    'Year': latest_year,\n",
     "    'Source': 'WVS',\n",
-    "    'QuestionGroup': list(dataset.get_group_questions().keys())[0],\n",
-    "    'Question': dataset.get_group_questions()[list(dataset.get_group_questions().keys())[0]][0],\n",
+    "    'QuestionGroup': list(service.get_groups().keys())[0],\n",
+    "    'Question': list(service.get_groups().values())[0][0],\n",
     "    'Score': 0.5,\n",
     "}\n",
-    "ingest_resp = client.post('/data', json=sample_record)\n",
-    "assert ingest_resp.status_code == 200\n",
+    "snapshot = service.add_record(sample_record)\n",
+    "display(Markdown(f\"\u2705 Added record via helper service; dataset now tracks {snapshot['records']} entries.\"))\n",
+    "\n",
+    "service.add_group_member(\n",
+    "    group_name='Demo Helpers',\n",
+    "    member_name='Analyst',\n",
+    "    responses={sample_record['QuestionGroup']: {sample_record['Question']: sample_record['Score']}},\n",
+    "    reference_year=latest_year,\n",
+    ")\n",
+    "profile = service.get_group_profile('Demo Helpers')\n",
+    "display(Markdown(f\"Computed profile for Demo Helpers with {len(profile)} question entries.\"))\n",
+    "\n",
+    "# Clean up temporary artefacts\n",
     "dataset.data = dataset.data[dataset.data['Country'] != 'Testland']\n",
-    "display(Markdown(\"✅ FastAPI endpoints responded successfully.\"))"
+    "dataset.country_data = dataset.country_data[dataset.country_data['Country'] != 'Testland']\n",
+    "group_manager.groups.pop('Demo Helpers', None)\n",
+    "dataset._refresh_metadata()\n"
    ]
   },
   {
@@ -1945,7 +1711,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "6da45f86",
    "metadata": {
     "execution": {
@@ -1955,30 +1721,17 @@
      "shell.execute_reply": "2025-10-02T16:16:16.672293Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "Sample response (cached or placeholder): OpenAI client not configured. Set your API key with `insight_generator.set_api_key('sk-...')`."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example usage (commented out to avoid accidental execution without a key):\n",
     "# insight_generator.set_api_key('sk-...')\n",
-    "sample_response = insight_generator.generate(\n",
+    "sample_response = service.generate_insight(\n",
     "    'question_basis',\n",
     "    score=0.62,\n",
     "    question='Generalized Trust',\n",
     "    source='World Values Survey',\n",
     ")\n",
-    "display(Markdown(f\"Sample response (cached or placeholder): {sample_response}\"))"
+    "display(Markdown(f\"Sample response (cached or placeholder): {sample_response}\"))\n"
    ]
   },
   {
@@ -2499,7 +2252,7 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_41d0bc085c69484c941d8df9fda249fa",
-       "placeholder": "​",
+       "placeholder": "\u200b",
        "style": "IPY_MODEL_3439762ff2cd4a34bcbecd49b63fef32",
        "tabbable": null,
        "tooltip": null,
@@ -4051,7 +3804,7 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_b3c01ebc996b46ab8983597643f0dd54",
-       "placeholder": "​",
+       "placeholder": "\u200b",
        "style": "IPY_MODEL_0951632ac8eb49178b587461cdc919dd",
        "tabbable": null,
        "tooltip": null,
@@ -6655,7 +6408,7 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_1a9c7643981d496d8acb7c7df28c3e9a",
-       "placeholder": "​",
+       "placeholder": "\u200b",
        "style": "IPY_MODEL_12efb6775cf6406a836e83fd138902d5",
        "tabbable": null,
        "tooltip": null,


### PR DESCRIPTION
## Summary
- update the setup and introduction cells to drop FastAPI-specific dependencies and messaging
- add a `CultureExplorerService` helper that exposes the culture dataset features without relying on a web server
- refresh the verification and insight cells to exercise the new service directly inside the notebook

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df106904648322901b5942e887bd12